### PR TITLE
Revert common_msgs renames

### DIFF
--- a/diagnostic_msgs/msg/DiagnosticStatus.msg
+++ b/diagnostic_msgs/msg/DiagnosticStatus.msg
@@ -2,10 +2,10 @@
 # 
 
 # Possible levels of operations
-byte DIAG_OK=0
-byte DIAG_WARN=1
-byte DIAG_ERROR=2
-byte DIAG_STALE=3
+byte OK=0
+byte WARN=1
+byte ERROR=2
+byte STALE=3
 
 byte level # level of operation enumerated above 
 string name # a description of the test/component reporting

--- a/visualization_msgs/msg/Marker.msg
+++ b/visualization_msgs/msg/Marker.msg
@@ -13,10 +13,10 @@ uint8 TEXT_VIEW_FACING=9
 uint8 MESH_RESOURCE=10
 uint8 TRIANGLE_LIST=11
 
-uint8 MK_ADD=0
-uint8 MK_MODIFY=0
-uint8 MK_DELETE=2
-uint8 MK_DELETEALL=3
+uint8 ADD=0
+uint8 MODIFY=0
+uint8 DELETE=2
+uint8 DELETEALL=3
 
 Header header                        # header for time/frame information
 string ns                            # Namespace to place this object in... used in conjunction with id to create a unique name for the object


### PR DESCRIPTION
This reverts commit 07e95df64cd59a51c39296702522139c6e9f1877.

This is part of a fix for https://github.com/ms-iot/ROSOnWindows/issues/34